### PR TITLE
Improve crawler templates and logging

### DIFF
--- a/CRAWLER_SPEC.md
+++ b/CRAWLER_SPEC.md
@@ -1,0 +1,10 @@
+# Crawler Specification
+
+## Rule 1: Follow only `support.microsoft.com` links
+## Rule 2: Delay 1 sec between requests
+## Rule 3: Save raw HTML under `data/raw/`
+## Rule 4: Parse pages into JSON with title, TOC and sections
+## Rule 5: Download images locally and update references
+## Rule 6: Write parsed JSON files to `data/processed/`
+## Rule 7: Emit `logger.info` messages at every major step
+## Rule 8: Render all pages with `handbook_template.md` into `output/handbook.md`

--- a/scripts/crawl.py
+++ b/scripts/crawl.py
@@ -1,91 +1,81 @@
+import argparse
+import json
+import os
 import time
 
-import os
-import json
-
-from utils import setup_logging, save_raw, load_config
-import requests, time, os
+import requests
 from jinja2 import Environment, FileSystemLoader
 from docxtpl import DocxTemplate, InlineImage
 from docx.shared import Inches
-import argparse
+
+from utils import setup_logging, save_raw, load_config
 
 logger = setup_logging()
 
-def crawl():
-        """
-    1) Load configuration from configs/crawler.yaml
-    2) For each URL: download HTML, save to data/raw/
-    3) Parse with parse_html(), save JSON to data/processed/
-    4) After all pages, render templates
-    """
-        
-    logger.info("1) Loading crawler config")
-    cfg = load_config("configs/crawler.yaml")
-    start_urls = cfg.get("start_urls", [])
-    delay      = cfg.get("delay_seconds", 1.0)
-    out_dir    = cfg.get("output_folder", "data/raw")
-    os.makedirs(out_dir, exist_ok=True)
 
-    logger.info(f"2) Beginning fetch loop (delay {delay!s}s)")
+def crawl():
+    """Fetch start URLs and store raw HTML in ``data/raw``."""
+    logger.info("1) Loading config from configs/crawler.yaml")
+    cfg = load_config()
+    start_urls = cfg.get("start_urls", [])
+    delay = cfg.get("delay_seconds", 1.0)
+    out_dir = cfg.get("output_folder", "data/raw")
+    os.makedirs(out_dir, exist_ok=True)
+    logger.info(f"2) Will fetch {len(start_urls)} start URLs")
+
     for url in start_urls:
-        logger.info(f"   → Fetching {url}")
+        logger.info(f"3) Fetching {url!r}")
         resp = requests.get(url)
-        filename = url.rstrip("/").split("/")[-1] + ".html"
-        path     = os.path.join(out_dir, filename)
-        save_raw(path, resp.text)
-        logger.info(f"   ✔ Saved raw HTML to {path}")
-        logger.info(f"   → Waiting {delay!s}s before next request")
+        name = url.rstrip("/").split("/")[-1] + ".html"
+        save_raw(out_dir, name, resp.text)
+        logger.info(f"   Saved {os.path.join(out_dir, name)}")
         time.sleep(delay)
 
-    logger.info("3) Fetch loop complete. Files in data/raw/")
-    # …then call parse, render, etc., each wrapped in logger.info()
-
-    # logger.info("4) Parsing raw HTML → JSON")
-    # for each file…
-    # logger.info(f"   → Parsing {raw_file}")
-    # …save processed JSON
-    # logger.info(f"   ✔ Wrote JSON to {processed_file}")
-
+    logger.info("4) Crawl complete")
 
 
 def render_md(data_files, template_path, output_path):
+    """Render parsed JSON pages into Markdown."""
     env = Environment(loader=FileSystemLoader('templates'))
     tmpl = env.get_template(template_path)
-    combined = []
-    for f in data_files:
-        with open(f, 'r', encoding='utf-8') as j:
-            combined.append(json.load(j))
-    out = tmpl.render(pages=combined)
-    with open(output_path, 'w', encoding='utf-8') as f:
-        f.write(out)
+    pages = [json.load(open(f, 'r', encoding='utf-8')) for f in data_files]
+    out = tmpl.render(pages=pages)
+    with open(output_path, 'w', encoding='utf-8') as fh:
+        fh.write(out)
+    logger.info(f"✅ Rendered Markdown to {output_path}")
 
 
 def render_docx(data_files, template_path, output_path):
+    """Render parsed JSON pages into a Word document."""
     tpl = DocxTemplate(os.path.join('templates', template_path))
     context = {'pages': []}
     for f in data_files:
         data = json.load(open(f, 'r', encoding='utf-8'))
-        # handle images in docx
         for sec in data.get('sections', []):
-            sec['images'] = [InlineImage(tpl, img, width=Inches(4)) for img in sec.get('images', [])]
+            sec['images'] = [InlineImage(tpl, img, width=Inches(4))
+                             for img in sec.get('images', [])]
         context['pages'].append(data)
     tpl.render(context)
     tpl.save(output_path)
+    logger.info(f"✅ Rendered DOCX to {output_path}")
 
 
 def main():
+    """Render all processed JSON into the chosen output format."""
     parser = argparse.ArgumentParser()
-    parser.add_argument('--format', choices=['md','docx'], default='md')
+    parser.add_argument('--format', choices=['md', 'docx'], default='md')
     args = parser.parse_args()
 
     proc = 'data/processed'
-    data_files = [os.path.join(proc, f) for f in os.listdir(proc) if f.endswith('.json')]
+    data_files = [os.path.join(proc, f) for f in os.listdir(proc)
+                  if f.endswith('.json')]
 
-    if args.format=='md':
+    if args.format == 'md':
         render_md(data_files, 'handbook_template.md', 'output/handbook.md')
     else:
-        render_docx(data_files, 'handbook_template.docx', 'output/handbook.docx')
+        render_docx(data_files, 'handbook_template.docx',
+                    'output/handbook.docx')
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     main()

--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -1,15 +1,16 @@
-import os
 import json
+import logging
+import os
+
 from bs4 import BeautifulSoup
-from utils import load_raw, save_processed, download_image
+
+from utils import load_raw, save_processed, download_image, setup_logging
+
+logger = setup_logging()
+
 
 def parse_html(html):
-      """
-    Extract:
-     - page title
-     - toc: list of {level, text, link}
-     - sections: list of {header, text, tables, images}
-    """
+    """Extract title, TOC and section data from a Visio support page."""
     soup = BeautifulSoup(html, 'html.parser')
     data = {
         'title': soup.h1.get_text(strip=True) if soup.h1 else '',
@@ -17,78 +18,70 @@ def parse_html(html):
         'sections': []
     }
 
-    # ── Pull the left-nav sidebar as H2 entries ──
     nav = soup.select_one('div.supLeftNavCategory')
     if nav:
-        # Category title
         title_link = nav.select_one('div.supLeftNavCategoryTitle > a.supLeftNavLink')
         if title_link:
-            data['toc'].append({
-                'level': 2,
-                'text': title_link.get_text(strip=True),
-                'link': title_link['href']
-            })
-        # Sub-articles
+            data['toc'].append({'level': 2,
+                                'text': title_link.get_text(strip=True),
+                                'link': title_link['href']})
         for a in nav.select('ul.supLeftNavArticles a.supLeftNavLink'):
-            data['toc'].append({
-                'level': 2,
-                'text': a.get_text(strip=True),
-                'link': a['href']
-            })
+            data['toc'].append({'level': 2,
+                                'text': a.get_text(strip=True),
+                                'link': a['href']})
 
-    # ── In-page H2 and H3 headers ──
     for h in soup.find_all(['h2', 'h3']):
         lvl = 2 if h.name == 'h2' else 3
-        data['toc'].append({
-            'level': lvl,
-            'text': h.get_text(strip=True),
-            'link': None
-        })
-        # Gather all content until the next H2/H3
+        data['toc'].append({'level': lvl,
+                            'text': h.get_text(strip=True),
+                            'link': None})
         content = []
         for sib in h.find_next_siblings():
             if sib.name in ['h2', 'h3']:
                 break
             content.append(sib)
-        # Extract text from paragraphs in this section
         texts = [c.get_text(strip=True) for c in content if c.name == 'p']
-        # Extract tables in this section
         tables = []
         for tbl in content:
             if tbl.name == 'table':
                 headers = [th.get_text(strip=True) for th in tbl.find_all('th')]
-                rows = [[td.get_text(strip=True) for td in tr.find_all('td')] 
+                rows = [[td.get_text(strip=True) for td in tr.find_all('td')]
                         for tr in tbl.find_all('tr')]
                 tables.append({'headers': headers, 'rows': rows})
-        # Download images in this section
         imgs = []
         for img in content:
             if img.name == 'img' and img.get('src'):
                 local = download_image(img['src'], 'images')
                 if local:
                     imgs.append(local)
-        # Append the section data
-        data['sections'].append({
-            'header': h.get_text(strip=True),
-            'text': "\n\n".join(texts),
-            'tables': tables,
-            'images': imgs
-        })
+        data['sections'].append({'header': h.get_text(strip=True),
+                                'text': "\n\n".join(texts),
+                                'tables': tables,
+                                'images': imgs})
+
+    logger.info(f"→ Parsed page {data['title']!r} with "
+                f"{len(data['toc'])} TOC entries and "
+                f"{len(data['sections'])} sections")
     return data
 
+
 def parse():
+    """Parse all HTML files in ``data/raw`` and write JSON to ``data/processed``."""
     raw_dir = 'data/raw'
     proc_dir = 'data/processed'
     os.makedirs(proc_dir, exist_ok=True)
+    logger.info(f"1) Parsing raw HTML from {raw_dir}")
     for fname in os.listdir(raw_dir):
         if not fname.endswith('.html'):
             continue
+        logger.info(f"2) Processing {fname}")
         path = os.path.join(raw_dir, fname)
         html = load_raw(path)
-        data = parse_html(html)
+        page = parse_html(html)
         out_name = fname.replace('.html', '.json')
-        save_processed(proc_dir, out_name, data)
-        print(f"Processed {fname} -> {out_name}")
+        save_processed(proc_dir, out_name, page)
+        logger.info(f"   → Saved {out_name}")
+
 
 if __name__ == '__main__':
     parse()

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,10 +1,14 @@
+import json
 import logging
 import os
-import json
-import requests
 from datetime import datetime
 
+import requests
+import yaml
+
+
 def setup_logging(log_dir="data/logs"):
+    """Configure console and file logging."""
     os.makedirs(log_dir, exist_ok=True)
     log_path = os.path.join(log_dir, f"{datetime.now():%Y%m%d_%H%M%S}.log")
     logging.basicConfig(
@@ -15,24 +19,31 @@ def setup_logging(log_dir="data/logs"):
             logging.StreamHandler()
         ]
     )
-    return logging.getLogger()
+    return logging.getLogger(__name__)
+
 
 def save_raw(folder, name, text):
+    """Write raw HTML ``text`` to ``folder/name``."""
+    os.makedirs(folder, exist_ok=True)
     with open(os.path.join(folder, name), 'w', encoding='utf-8') as f:
         f.write(text)
 
 
 def load_raw(path):
+    """Read text from ``path``."""
     with open(path, 'r', encoding='utf-8') as f:
         return f.read()
 
 
 def save_processed(folder, name, data):
+    """Serialize ``data`` as JSON to ``folder/name``."""
+    os.makedirs(folder, exist_ok=True)
     with open(os.path.join(folder, name), 'w', encoding='utf-8') as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
 
 
 def download_image(url, folder):
+    """Download an image to ``folder`` and return its local path."""
     os.makedirs(folder, exist_ok=True)
     fname = url.split('/')[-1]
     path = os.path.join(folder, fname)
@@ -43,10 +54,8 @@ def download_image(url, folder):
         return path
     return ''
 
-# utils.py  (add this at the bottom)
-
-import yaml
 
 def load_config(path="configs/crawler.yaml"):
+    """Load crawler configuration from ``path``."""
     with open(path, 'r', encoding='utf-8') as f:
         return yaml.safe_load(f)

--- a/templates/handbook_template.md
+++ b/templates/handbook_template.md
@@ -1,21 +1,25 @@
-{% raw %}
-<!-- top of handbook_template.md -->
-# {{ pages[0].title }}
-
-*Generated on {{ timestamp }}*
-
+---
+title:     {{ handbook_title }}
+date:      {{ date }}
+version:   {{ version }}
+author:    {{ author }}
 ---
 
-## Table of Contents
+<!-- TOC will be auto-injected here -->
 
-{% for item in pages[0].toc %}
-- **Level {{ item.level }}:** {{ item.text }} {% if item.link %}([link]({{ item.link }})){% endif %}
-{% endfor %}
-
----
+## What this template does
+- Renders a sequence of pages into a single handbook
+- Each page must supply:
+  - `title` (string)
+  - `toc` (list of `{ level, text, link }`)
+  - `sections` (list of `{ header, text, tables?, images? }`)
 
 {% for page in pages %}
 # {{ page.title }}
+
+{% for entry in page.toc %}
+{{ "#" * entry.level }} [{{ entry.text }}]({{ entry.link }})
+{% endfor %}
 
 {% for sec in page.sections %}
 ## {{ sec.header }}
@@ -23,19 +27,18 @@
 {{ sec.text }}
 
 {% if sec.tables %}
-| {{ sec.tables[0].headers | join(" | ") }} |
-|---{% for _ in sec.tables[0].headers %}|{% endfor %}
+| {{ sec.tables[0].headers | join(' | ') }} |
+|{{ ' --- |' * sec.tables[0].headers|length }}
+
 {% for row in sec.tables[0].rows %}
-| {{ row | join(" | ") }} |
+| {{ row | join(' | ') }} |
 {% endfor %}
 {% endif %}
-
 {% if sec.images %}
 {% for img in sec.images %}
 ![image]({{ img }})
 {% endfor %}
 {% endif %}
+{% endfor %}
 
 {% endfor %}
-{% endfor %}
-{% endraw %}


### PR DESCRIPTION
## Summary
- restructure handbook template with YAML front-matter
- document crawling rules in `CRAWLER_SPEC.md`
- add detailed logging and docstrings in `crawl.py`
- instrument `parse.py` with step-by-step logging
- clean up utility helpers with docstrings

## Testing
- `python -m py_compile scripts/*.py`
- `python scripts/crawl.py --format md`

------
https://chatgpt.com/codex/tasks/task_e_68456b57ab6c832d8cd7dc8fbac7929c